### PR TITLE
Change devtools url

### DIFF
--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -262,7 +262,6 @@ customElements.define('developer-tooling', class extends HTMLElement {
         navigator.clipboard.writeText(`devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=127.0.0.1:${this.port}/${sessionId}`)
       })
       div.querySelector('.open-in-chrome').addEventListener('click', () => {
-        // openChrome(`devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=127.0.0.1:${this.port}/${sessionId}`)
         openChrome('chrome://inspect')
       })
       div.querySelector('.remove').addEventListener('click', () => {


### PR DESCRIPTION
This should fix that direct links to `devtools://...` doesn't always open. With this fix, there'll be a direct link to `chrome://inspect`