### PR TITLE
Change default inspector port to 9222

### DIFF
--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -7,7 +7,7 @@ import { spawn } from 'child_process'
 
 customElements.define('developer-tooling', class extends HTMLElement {
   router = null
-  port = 9342
+  port = 9222
 
   constructor () {
     super()


### PR DESCRIPTION
By default chrome://inspect listens to 9222 and 9229.
9229 is default by Node's inspector, and 9222 seems to be default for Edge DevTools Protocol. I chose 9222 as I figured we have a lot of users that might be using Node.

Note that the user will get an error if the port is in use, and can easily change it by themselves