### PR TITLE
Fix setup button on windows not working

### DIFF
--- a/lib/system-status.js
+++ b/lib/system-status.js
@@ -6,7 +6,7 @@ import { spawnSync } from 'child_process'
 const { config } = Pear
 
 const BIN = path.join(config.pearDir, 'bin')
-const WIN_REGVAL_MATCHER = /REG_SZ\s+([^\r\n]+)\r?\n/
+const WIN_REGVAL_MATCHER = /(REG_SZ|REG_EXPAND_SZ)\s+([^\r\n]+)\r?\n/
 
 const isWin = process.platform === 'win32'
 
@@ -183,7 +183,7 @@ customElements.define('system-status', class extends HTMLElement {
       if (hasPear) process.env.PATH = `${BIN}:${process.env.PATH}`
     } else {
       const currentPath = spawnSync('reg', ['query', 'HKCU\\Environment', '/v', 'Path'])
-        .stdout.toString()?.match(WIN_REGVAL_MATCHER)?.[1]
+        .stdout.toString()?.match(WIN_REGVAL_MATCHER)?.[2]
 
       if (!process.env.PATH?.includes(BIN) && currentPath?.includes(BIN)) {
         process.env.PATH = `${BIN}${path.delimiter}${process.env.PATH}`
@@ -214,14 +214,15 @@ customElements.define('system-status', class extends HTMLElement {
       }
 
       const pathMatches = pathQuery.stdout.toString()?.match(WIN_REGVAL_MATCHER)
-      if (!Array.isArray(pathMatches) || pathMatches.length !== 2) {
+      if (!Array.isArray(pathMatches) || pathMatches.length !== 3) {
         throw new Error('Failed to extract user PATH')
       }
 
-      const originalPath = pathMatches[1]
+      const regKeyType = pathMatches[1]
+      const originalPath = pathMatches[2]
       if (!originalPath || !originalPath.includes(BIN)) {
         const newPath = originalPath ? `${BIN};${originalPath}` : BIN
-        spawnSync('reg', ['add', 'HKCU\\Environment', '/v', 'Path', '/t', 'REG_SZ', '/d', newPath, '/f'])
+        spawnSync('reg', ['add', 'HKCU\\Environment', '/v', 'Path', '/t', regKeyType, '/d', newPath, '/f'])
       }
     } else {
       const runtime = path.join('..', runtimeSubpath)


### PR DESCRIPTION
The Automatic Setup Completion button fails silently on win10 and win11 due to regex not being able to match the registry key data type. It can be either REG_SZ or REG_EXPAND_SZ.

The updated regex now includes the reg key data type that was matched and sets it dynamically.