### PR TITLE
adjust router input instead of hmtl text

### DIFF
--- a/lib/docs-viewer.js
+++ b/lib/docs-viewer.js
@@ -136,7 +136,12 @@ customElements.define('docs-viewer', class extends HTMLElement {
     // remove gitbook embed syntax
     output = output.replace(/{% embed url="([^"]+)" %}\s*(.*?)\s*{% embeded %}/g, '> [$2]($1)')
 
-    // replace urls
+    return output
+  }
+
+  replaceURLs (input){
+    let output = input
+
     output =  output.replace(/(?<!((vendor\/pear-docs)|(\.\.)))\/building-blocks/g, '/vendor/pear-docs/building-blocks')
     output =  output.replace(/(?<!((vendor\/pear-docs)|(\.\.)))\/guide/g, '/vendor/pear-docs/guide')
     output =  output.replace(/(?<!((vendor\/pear-docs)|(\.\.)))\/helpers/g, '/vendor/pear-docs/helpers')
@@ -153,7 +158,8 @@ customElements.define('docs-viewer', class extends HTMLElement {
 
   async load (page = '/') {
     if (page === '/') page = this.entry
-    const html = await fetch(page)
+    const adjustedPage = this.replaceURLs(page)
+    const html = await fetch(adjustedPage)
     const text = await marked.parse(this.patchSyntax(await html.text()))
     this.panel.querySelector('slot').innerHTML = text
     this.panel.style.display = ''


### PR DESCRIPTION
Previosly the router urls were changed in the fetched html text (for clicking anchors)... now they are being adjusted on input instead (before fetching), so it also works with cli urls