### PR TITLE
fix root wakeup routing

### DIFF
--- a/lib/app-router.js
+++ b/lib/app-router.js
@@ -116,6 +116,7 @@ customElements.define('app-router', class AppRouter extends HTMLElement {
   }
 
   async load (pathname = '/', opts = {}) {
+    if (pathname === '') pathname = '/'
     pathname = this.remap(pathname)
     if (this.page === pathname && this.fragment === opts.fragment && this.query === opts.query) return
     this.page = pathname


### PR DESCRIPTION
pear://runtime as a wakeup routed to "not found" because it passes an empty string to router load

-> fix: router load defaults empty string to '/' 